### PR TITLE
fix: upgrade shell-quote to 1.8.4 (CVE-2026-9277)

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -12,7 +12,8 @@
         "@docusaurus/preset-classic": "3.10.0",
         "clsx": "^2.0.0",
         "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "react-dom": "^18.0.0",
+        "shell-quote": "^1.8.4"
       }
     },
     "node_modules/@algolia/abtesting": {
@@ -16519,9 +16520,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/site/package.json
+++ b/site/package.json
@@ -17,6 +17,7 @@
     "@docusaurus/preset-classic": "3.10.0",
     "clsx": "^2.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "shell-quote": "^1.8.4"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade shell-quote from 1.8.3 to 1.8.4 to fix CVE-2026-9277.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-9277 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-9277` |
| **File** | `site/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: shell-quote: shell-quote: Arbitrary code execution via command injection due to unescaped line terminators

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-9277` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `site/package.json`
- `site/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
